### PR TITLE
Add comments in posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -91,7 +91,7 @@ delicious_user:
 delicious_count: 3
 
 # Disqus Comments
-disqus_short_name:
+disqus_short_name: intodaysstoryblog
 disqus_show_comment_count: true
 
 # Google Analytics


### PR DESCRIPTION
### Why is this change necessary?

For the ability disqus in posts.
### How does it address the issue?

Creating an account in https://disqus.com
And ability disqus in config file
### What side effects does this change have?

Now is possible comment posts
