### PR TITLE
Remove twitter and facebook buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,7 +72,7 @@ github_skip_forks: true
 
 # Twitter
 twitter_user: devlandia
-twitter_tweet_button: true
+twitter_tweet_button: false
 
 # Google +1
 google_plus_one: false
@@ -99,4 +99,4 @@ disqus_show_comment_count: true
 google_analytics_tracking_id: UA-41348103-6
 
 # Facebook Like
-facebook_like: true
+facebook_like: false


### PR DESCRIPTION
### Why is this change necessary?

Because, the Disqus already provides the option to share on facebook and twitter
### How does it address the issue?

Alter two fields in config file
### What side effects does this change have?

Now it is possible share on facebook and twitter only the Disqus
